### PR TITLE
Be/init/docker compose

### DIFF
--- a/BE/.gitignore
+++ b/BE/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# 환경 변수 파일
+.env

--- a/BE/Dockerfile
+++ b/BE/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:7.6.1-jdk17 AS build
+WORKDIR /app
+COPY . .
+RUN gradle build --no-daemon -x test
+
+FROM openjdk:17-slim
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"] 

--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -1,16 +1,14 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.2.3'
+	id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.stockr'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+	sourceCompatibility = '17'
 }
 
 configurations {
@@ -24,19 +22,36 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'com.mysql:mysql-connector-j:8.0.33'
-	// implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	// implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// Spring Boot Starters
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-//	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	// implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.kafka:spring-kafka'
+	
+	// Database
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	
+	// Redis
+	implementation 'org.apache.commons:commons-pool2'
+	
+	// WebSocket
+	implementation 'org.webjars:webjars-locator-core'
+	implementation 'org.webjars:sockjs-client:1.5.1'
+	implementation 'org.webjars:stomp-websocket:2.3.4'
+	
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
+	
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	// testImplementation 'org.springframework.kafka:spring-kafka-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+	
+	// Monitoring & Management
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/BE/config/kafka/server_jaas.conf
+++ b/BE/config/kafka/server_jaas.conf
@@ -1,6 +1,0 @@
-KafkaServer {
-    org.apache.kafka.common.security.plain.PlainLoginModule required
-    username="${KAFKA_ADMIN_USERNAME}"
-    password="${KAFKA_ADMIN_PASSWORD}"
-    user_${KAFKA_ADMIN_USERNAME}="${KAFKA_ADMIN_PASSWORD}";
-}; 

--- a/BE/config/kafka/server_jaas.conf
+++ b/BE/config/kafka/server_jaas.conf
@@ -1,0 +1,6 @@
+KafkaServer {
+    org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="${KAFKA_ADMIN_USERNAME}"
+    password="${KAFKA_ADMIN_PASSWORD}"
+    user_${KAFKA_ADMIN_USERNAME}="${KAFKA_ADMIN_PASSWORD}";
+}; 

--- a/BE/docker-compose.yml
+++ b/BE/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   # MySQL - 종목 기본 정보 및 유사 종목 데이터 저장
   mysql:
@@ -37,9 +35,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 30s
 
-  # MongoDB - 시계열 데이터 저장
+  # MongoDB - 종목 뉴스 및 공시 데이터 저장
   mongodb:
     image: mongo:6.0
     container_name: stockr-mongodb
@@ -51,113 +48,120 @@ services:
       - "27117:27017"
     volumes:
       - mongodb_data:/data/db
-    command: mongod --auth
+      - ./init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
+    command: ["--auth"]
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet -u ${MONGO_INITDB_ROOT_USERNAME} -p ${MONGO_INITDB_ROOT_PASSWORD}
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 40s
 
-  # Redis - 실시간 시세 캐싱
+  # Redis - 캐시 및 세션 데이터 저장
   redis:
     image: redis:7.0
     container_name: stockr-redis
-    command: redis-server --requirepass ${REDIS_PASSWORD}
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
     ports:
       - "16379:6379"
     volumes:
       - redis_data:/data
+    command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly yes
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-  # Kafka & Zookeeper
+  # Zookeeper - Kafka 클러스터 관리
   zookeeper:
     image: confluentinc/cp-zookeeper:7.3.0
     container_name: stockr-zookeeper
     environment:
-      ZOOKEEPER_SERVER_ID: 1
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-      ALLOW_ANONYMOUS_LOGIN: "yes"
     ports:
-      - "12181:2181"
+      - "22181:2181"
     volumes:
       - zookeeper_data:/var/lib/zookeeper/data
       - zookeeper_log:/var/lib/zookeeper/log
     healthcheck:
-      test: echo ruok | nc localhost 2181 || exit 1
+      test: echo stat | nc localhost 2181
       interval: 10s
       timeout: 5s
       retries: 5
 
+  # Kafka - 실시간 데이터 스트리밍
   kafka:
     image: confluentinc/cp-kafka:7.3.0
     container_name: stockr-kafka
     depends_on:
-      zookeeper:
-        condition: service_healthy
+      - zookeeper
     ports:
-      - "19092:9092"
+      - "19092:19092"
+      - "29092:29092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:19092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:19092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_HEAP_OPTS: "-Xmx512M -Xms512M"
     volumes:
       - kafka_data:/var/lib/kafka/data
     healthcheck:
-      test: nc -z localhost 9092 || exit 1
-      interval: 10s
-      timeout: 5s
+      test: kafka-topics --bootstrap-server localhost:29092 --list
+      interval: 30s
+      timeout: 10s
       retries: 5
+      start_period: 30s
 
-  # Kafka UI - 카프카 모니터링 도구
+  # Kafka UI - Kafka 모니터링
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
     container_name: stockr-kafka-ui
     depends_on:
-      kafka:
-        condition: service_healthy
+      - kafka
     ports:
-      - "18081:8080"
+      - "8989:8080"
     environment:
-      KAFKA_CLUSTERS_0_NAME: stockr-kafka
+      KAFKA_CLUSTERS_0_NAME: stockr
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
-      KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL: PLAINTEXT
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
 
   # Spring Boot Application
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: stockr-app
     depends_on:
-      mysql:
-        condition: service_healthy
-      mongodb:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      kafka:
-        condition: service_healthy
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
-      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
-      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
-      SPRING_DATA_MONGODB_URI: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongodb:27017/${MONGO_DATABASE}?authSource=admin
-      SPRING_REDIS_HOST: redis
-      SPRING_REDIS_PORT: 6379
-      SPRING_REDIS_PASSWORD: ${REDIS_PASSWORD}
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+      - mysql
+      - mongodb
+      - redis
+      - kafka
     ports:
       - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      MYSQL_HOST: mysql
+      MYSQL_PORT: 3306
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MONGO_HOST: mongodb
+      MONGO_PORT: 27017
+      MONGO_DATABASE: ${MONGO_DATABASE}
+      MONGO_USER: ${MONGO_INITDB_ROOT_USERNAME}
+      MONGO_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      KAFKA_BOOTSTRAP_SERVERS: kafka:29092
 
 volumes:
   mysql_data:

--- a/BE/docker-compose.yml
+++ b/BE/docker-compose.yml
@@ -10,11 +10,18 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul
     ports:
-      - "3306:3306"
+      - "13306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-authentication-plugin=mysql_native_password
+      - --innodb-buffer-pool-size=256M
+      - --innodb-log-file-size=64M
+      - --max-allowed-packet=128M
     healthcheck:
       test:
         [
@@ -30,6 +37,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
 
   # MongoDB - 시계열 데이터 저장
   mongodb:
@@ -40,7 +48,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
       MONGO_INITDB_DATABASE: ${MONGO_DATABASE}
     ports:
-      - "27017:27017"
+      - "27117:27017"
     volumes:
       - mongodb_data:/data/db
     command: mongod --auth
@@ -56,7 +64,7 @@ services:
     container_name: stockr-redis
     command: redis-server --requirepass ${REDIS_PASSWORD}
     ports:
-      - "6379:6379"
+      - "16379:6379"
     volumes:
       - redis_data:/data
     healthcheck:
@@ -70,15 +78,17 @@ services:
     image: confluentinc/cp-zookeeper:7.3.0
     container_name: stockr-zookeeper
     environment:
+      ZOOKEEPER_SERVER_ID: 1
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-      ZOOKEEPER_SERVER_CNXN_FACTORY: org.apache.zookeeper.server.NettyServerCnxnFactory
-      ZOOKEEPER_AUTH_PROVIDER_1: org.apache.zookeeper.server.auth.SASLAuthenticationProvider
-      ZOOKEEPER_REQUIRE_CLIENT_AUTH_SCHEME: sasl
+      ALLOW_ANONYMOUS_LOGIN: "yes"
     ports:
-      - "2181:2181"
+      - "12181:2181"
+    volumes:
+      - zookeeper_data:/var/lib/zookeeper/data
+      - zookeeper_log:/var/lib/zookeeper/log
     healthcheck:
-      test: echo srvr | nc localhost 2181 || exit 1
+      test: echo ruok | nc localhost 2181 || exit 1
       interval: 10s
       timeout: 5s
       retries: 5
@@ -87,23 +97,23 @@ services:
     image: confluentinc/cp-kafka:7.3.0
     container_name: stockr-kafka
     depends_on:
-      - zookeeper
+      zookeeper:
+        condition: service_healthy
     ports:
-      - "9092:9092"
+      - "19092:9092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_SUPER_USERS: User:${KAFKA_ADMIN_USERNAME}
-      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
-      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SASL_PLAINTEXT
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      ALLOW_PLAINTEXT_LISTENER: "yes"
     volumes:
-      - ./config/kafka/server_jaas.conf:/etc/kafka/kafka_server_jaas.conf:ro
+      - kafka_data:/var/lib/kafka/data
     healthcheck:
       test: nc -z localhost 9092 || exit 1
       interval: 10s
@@ -115,18 +125,44 @@ services:
     image: provectuslabs/kafka-ui:latest
     container_name: stockr-kafka-ui
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
     ports:
-      - "8081:8080"
+      - "18081:8080"
     environment:
       KAFKA_CLUSTERS_0_NAME: stockr-kafka
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
-      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
-      KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL: SASL_PLAINTEXT
-      KAFKA_CLUSTERS_0_PROPERTIES_SASL_MECHANISM: PLAIN
-      KAFKA_CLUSTERS_0_PROPERTIES_SASL_JAAS_CONFIG: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="${KAFKA_ADMIN_USERNAME}" password="${KAFKA_ADMIN_PASSWORD}";'
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL: PLAINTEXT
+
+  # Spring Boot Application
+  app:
+    build: .
+    container_name: stockr-app
+    depends_on:
+      mysql:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      SPRING_DATA_MONGODB_URI: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongodb:27017/${MONGO_DATABASE}?authSource=admin
+      SPRING_REDIS_HOST: redis
+      SPRING_REDIS_PORT: 6379
+      SPRING_REDIS_PASSWORD: ${REDIS_PASSWORD}
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+    ports:
+      - "8080:8080"
 
 volumes:
   mysql_data:
   mongodb_data:
   redis_data:
+  zookeeper_data:
+  zookeeper_log:
+  kafka_data:

--- a/BE/docker-compose.yml
+++ b/BE/docker-compose.yml
@@ -1,0 +1,132 @@
+version: "3.8"
+
+services:
+  # MySQL - 종목 기본 정보 및 유사 종목 데이터 저장
+  mysql:
+    image: mysql:8.0
+    container_name: stockr-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "mysqladmin",
+          "ping",
+          "-h",
+          "localhost",
+          "-u",
+          "${MYSQL_USER}",
+          "-p${MYSQL_PASSWORD}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # MongoDB - 시계열 데이터 저장
+  mongodb:
+    image: mongo:6.0
+    container_name: stockr-mongodb
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
+      MONGO_INITDB_DATABASE: ${MONGO_DATABASE}
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    command: mongod --auth
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet -u ${MONGO_INITDB_ROOT_USERNAME} -p ${MONGO_INITDB_ROOT_PASSWORD}
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Redis - 실시간 시세 캐싱
+  redis:
+    image: redis:7.0
+    container_name: stockr-redis
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Kafka & Zookeeper
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.3.0
+    container_name: stockr-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_SERVER_CNXN_FACTORY: org.apache.zookeeper.server.NettyServerCnxnFactory
+      ZOOKEEPER_AUTH_PROVIDER_1: org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+      ZOOKEEPER_REQUIRE_CLIENT_AUTH_SCHEME: sasl
+    ports:
+      - "2181:2181"
+    healthcheck:
+      test: echo srvr | nc localhost 2181 || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kafka:
+    image: confluentinc/cp-kafka:7.3.0
+    container_name: stockr-kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_SUPER_USERS: User:${KAFKA_ADMIN_USERNAME}
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SASL_PLAINTEXT
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf"
+    volumes:
+      - ./config/kafka/server_jaas.conf:/etc/kafka/kafka_server_jaas.conf:ro
+    healthcheck:
+      test: nc -z localhost 9092 || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Kafka UI - 카프카 모니터링 도구
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: stockr-kafka-ui
+    depends_on:
+      - kafka
+    ports:
+      - "8081:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: stockr-kafka
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL: SASL_PLAINTEXT
+      KAFKA_CLUSTERS_0_PROPERTIES_SASL_MECHANISM: PLAIN
+      KAFKA_CLUSTERS_0_PROPERTIES_SASL_JAAS_CONFIG: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="${KAFKA_ADMIN_USERNAME}" password="${KAFKA_ADMIN_PASSWORD}";'
+
+volumes:
+  mysql_data:
+  mongodb_data:
+  redis_data:

--- a/BE/init-mongo.js
+++ b/BE/init-mongo.js
@@ -1,0 +1,12 @@
+db = db.getSiblingDB("admin");
+
+db.createUser({
+  user: process.env.MONGO_INITDB_ROOT_USERNAME,
+  pwd: process.env.MONGO_INITDB_ROOT_PASSWORD,
+  roles: [{ role: "root", db: "admin" }],
+});
+
+db = db.getSiblingDB(process.env.MONGO_DATABASE);
+
+db.createCollection("news");
+db.createCollection("disclosures");

--- a/BE/src/main/java/com/stockr/be/common/controller/HealthCheckController.java
+++ b/BE/src/main/java/com/stockr/be/common/controller/HealthCheckController.java
@@ -1,0 +1,72 @@
+package com.stockr.be.common.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.bson.Document;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/health")
+public class HealthCheckController {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @GetMapping
+    public ResponseEntity<Map<String, String>> checkHealth() {
+        Map<String, String> status = new HashMap<>();
+        status.put("status", "UP");
+
+        try {
+            // MySQL 헬스체크
+            jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+            status.put("mysql", "UP");
+        } catch (Exception e) {
+            status.put("mysql", "DOWN - " + e.getMessage());
+        }
+
+        try {
+            // MongoDB 헬스체크
+            mongoTemplate.getDb().runCommand(new Document("ping", 1));
+            status.put("mongodb", "UP");
+        } catch (Exception e) {
+            status.put("mongodb", "DOWN - " + e.getMessage());
+        }
+
+        try {
+            // Redis 헬스체크
+            redisTemplate.opsForValue().get("health");
+            status.put("redis", "UP");
+        } catch (Exception e) {
+            status.put("redis", "DOWN - " + e.getMessage());
+        }
+
+        try {
+            // Kafka 헬스체크
+            kafkaTemplate.send("health-check", "ping");
+            status.put("kafka", "UP");
+        } catch (Exception e) {
+            status.put("kafka", "DOWN - " + e.getMessage());
+        }
+
+        return ResponseEntity.ok(status);
+    }
+} 

--- a/BE/src/main/java/com/stockr/be/common/controller/HealthCheckController.java
+++ b/BE/src/main/java/com/stockr/be/common/controller/HealthCheckController.java
@@ -1,5 +1,9 @@
 package com.stockr.be.common.controller;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -9,10 +13,6 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.bson.Document;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/health")
@@ -31,42 +31,47 @@ public class HealthCheckController {
     private KafkaTemplate<String, String> kafkaTemplate;
 
     @GetMapping
-    public ResponseEntity<Map<String, String>> checkHealth() {
+    public ResponseEntity<Map<String, String>> healthCheck() {
         Map<String, String> status = new HashMap<>();
-        status.put("status", "UP");
 
+        // MySQL 헬스체크
         try {
-            // MySQL 헬스체크
             jdbcTemplate.queryForObject("SELECT 1", Integer.class);
             status.put("mysql", "UP");
         } catch (Exception e) {
             status.put("mysql", "DOWN - " + e.getMessage());
         }
 
+        // MongoDB 헬스체크
         try {
-            // MongoDB 헬스체크
             mongoTemplate.getDb().runCommand(new Document("ping", 1));
             status.put("mongodb", "UP");
         } catch (Exception e) {
             status.put("mongodb", "DOWN - " + e.getMessage());
         }
 
+        // Redis 헬스체크
         try {
-            // Redis 헬스체크
-            redisTemplate.opsForValue().get("health");
-            status.put("redis", "UP");
+            redisTemplate.opsForValue().set("health", "check");
+            String value = redisTemplate.opsForValue().get("health");
+            if ("check".equals(value)) {
+                status.put("redis", "UP");
+            } else {
+                status.put("redis", "DOWN - Value mismatch");
+            }
         } catch (Exception e) {
             status.put("redis", "DOWN - " + e.getMessage());
         }
 
+        // Kafka 헬스체크
         try {
-            // Kafka 헬스체크
-            kafkaTemplate.send("health-check", "ping");
+            kafkaTemplate.send("health-check", "test").get();
             status.put("kafka", "UP");
         } catch (Exception e) {
             status.put("kafka", "DOWN - " + e.getMessage());
         }
 
+        status.put("status", "UP");
         return ResponseEntity.ok(status);
     }
-} 
+}

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
   # DATABASE
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
-    username: ${MYSQL_USER}
-    password: ${MYSQL_PASSWORD}
+    url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:13306}/${MYSQL_DATABASE:stockr}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    username: ${MYSQL_USER:stockr}
+    password: ${MYSQL_PASSWORD:stockr123!}
 
   jpa:
     hibernate:
@@ -18,16 +18,16 @@ spring:
         format_sql: true # SQL 쿼리를 예쁘게 포맷팅
         dialect: org.hibernate.dialect.MySQLDialect
 
-  #  # MONGODB
+  # MONGODB
   data:
     mongodb:
-      uri: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@localhost:27017/${MONGO_DATABASE}?authSource=admin
+      uri: mongodb://${MONGO_USER:stockr}:${MONGO_PASSWORD:stockr123!}@${MONGO_HOST:localhost}:${MONGO_PORT:27117}/${MONGO_DATABASE:stockr}?authSource=admin
 
-  #  # REDIS
+  # REDIS
   redis:
-    host: localhost
-    port: 6379
-    password: ${REDIS_PASSWORD}
+    host: ${REDIS_HOST:localhost}
+    port: ${REDIS_PORT:16379}
+    password: ${REDIS_PASSWORD:stockr123!}
     timeout: 3000
     lettuce:
       pool:
@@ -36,15 +36,9 @@ spring:
         min-idle: 0
         max-wait: -1ms
 
-  #  # KAFKA
+  # KAFKA
   kafka:
-    bootstrap-servers: localhost:9092
-    security:
-      protocol: SASL_PLAINTEXT
-    sasl:
-      mechanism: PLAIN
-      jaas:
-        config: org.apache.kafka.common.security.plain.PlainLoginModule required username='${KAFKA_ADMIN_USERNAME}' password='${KAFKA_ADMIN_PASSWORD}';
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:19092}
     consumer:
       group-id: stockr-group
       auto-offset-reset: earliest
@@ -52,16 +46,9 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       properties:
         spring.json.trusted.packages: "*"
-        security.protocol: SASL_PLAINTEXT
-        sasl.mechanism: PLAIN
-        sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username='${KAFKA_ADMIN_USERNAME}' password='${KAFKA_ADMIN_PASSWORD}';
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
-      properties:
-        security.protocol: SASL_PLAINTEXT
-        sasl.mechanism: PLAIN
-        sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username='${KAFKA_ADMIN_USERNAME}' password='${KAFKA_ADMIN_PASSWORD}';
 
   #  # WebSocket
   websocket:

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
   # DATABASE
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/stockr_db?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
-    username: root
-    password: root
+    url: jdbc:mysql://localhost:3306/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
 
   jpa:
     hibernate:
@@ -18,29 +18,60 @@ spring:
         format_sql: true # SQL 쿼리를 예쁘게 포맷팅
         dialect: org.hibernate.dialect.MySQLDialect
 
-#  # MONGODB
-#  data:
-#    mongodb:
-#      uri: mongodb://localhost:27017/stock_data
-#
-#  # REDIS
-#  redis:
-#    host: localhost
-#    port: 6379
-#
-#  # KAFKA
-#  kafka:
-#    bootstrap-servers: localhost:9092
-#    consumer:
-#      group-id: stockr-group
-#      auto-offset-reset: earliest
-#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#    producer:
-#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-#      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+  #  # MONGODB
+  data:
+    mongodb:
+      uri: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@localhost:27017/${MONGO_DATABASE}?authSource=admin
+
+  #  # REDIS
+  redis:
+    host: localhost
+    port: 6379
+    password: ${REDIS_PASSWORD}
+    timeout: 3000
+    lettuce:
+      pool:
+        max-active: 8
+        max-idle: 8
+        min-idle: 0
+        max-wait: -1ms
+
+  #  # KAFKA
+  kafka:
+    bootstrap-servers: localhost:9092
+    security:
+      protocol: SASL_PLAINTEXT
+    sasl:
+      mechanism: PLAIN
+      jaas:
+        config: org.apache.kafka.common.security.plain.PlainLoginModule required username='${KAFKA_ADMIN_USERNAME}' password='${KAFKA_ADMIN_PASSWORD}';
+    consumer:
+      group-id: stockr-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
+        security.protocol: SASL_PLAINTEXT
+        sasl.mechanism: PLAIN
+        sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username='${KAFKA_ADMIN_USERNAME}' password='${KAFKA_ADMIN_PASSWORD}';
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      properties:
+        security.protocol: SASL_PLAINTEXT
+        sasl.mechanism: PLAIN
+        sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username='${KAFKA_ADMIN_USERNAME}' password='${KAFKA_ADMIN_PASSWORD}';
+
+  #  # WebSocket
+  websocket:
+    allowed-origins: "*"
+    endpoint: /ws
+    topic-prefix: /topic
+    application-prefix: /app
 
 logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace # ? 로 표시되는 바인딩 파라미터 값까지 로그로 출력
+    com.stockr.be: debug

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
   # DATABASE
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:13306}/${MYSQL_DATABASE:stockr}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
-    username: ${MYSQL_USER:stockr}
-    password: ${MYSQL_PASSWORD:stockr123!}
+    url: jdbc:mysql://stockr-mysql:3306/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
 
   jpa:
     hibernate:
@@ -21,24 +21,33 @@ spring:
   # MONGODB
   data:
     mongodb:
-      uri: mongodb://${MONGO_USER:stockr}:${MONGO_PASSWORD:stockr123!}@${MONGO_HOST:localhost}:${MONGO_PORT:27117}/${MONGO_DATABASE:stockr}?authSource=admin
-
-  # REDIS
-  redis:
-    host: ${REDIS_HOST:localhost}
-    port: ${REDIS_PORT:16379}
-    password: ${REDIS_PASSWORD:stockr123!}
-    timeout: 3000
-    lettuce:
-      pool:
-        max-active: 8
-        max-idle: 8
-        min-idle: 0
-        max-wait: -1ms
+      uri: mongodb://${MONGO_USER}:${MONGO_PASSWORD}@stockr-mongodb:27017/${MONGO_DATABASE}?authSource=admin
+    # REDIS
+    redis:
+      host: stockr-redis
+      port: 6379
+      password: ${REDIS_PASSWORD}
+      timeout: 5000
+      connect-timeout: 5000
+      client-type: lettuce
+      client-name: stockr-redis
+      database: 0
+      lettuce:
+        pool:
+          enabled: true
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+          max-wait: -1ms
+        shutdown-timeout: 100ms
+        cluster:
+          refresh:
+            period: 1000
+            adaptive: true
 
   # KAFKA
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:19092}
+    bootstrap-servers: stockr-kafka:29092
     consumer:
       group-id: stockr-group
       auto-offset-reset: earliest
@@ -50,15 +59,21 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
-  #  # WebSocket
+  # WebSocket
   websocket:
     allowed-origins: "*"
     endpoint: /ws
     topic-prefix: /topic
     application-prefix: /app
 
+  config:
+    activate:
+      on-profile: test
+
 logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace # ? 로 표시되는 바인딩 파라미터 값까지 로그로 출력
     com.stockr.be: debug
+    org.springframework.data.redis: debug
+    io.lettuce.core: debug

--- a/BE/src/test/java/com/stockr/be/StockrBeApplicationTests.java
+++ b/BE/src/test/java/com/stockr/be/StockrBeApplicationTests.java
@@ -1,13 +1,8 @@
 package com.stockr.be;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class StockrBeApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
 
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
 # Stoc.kr
-한국폴리텍대학 데이터분석과: 웹 개발 프로젝트 리포지토리
+
+실시간 주식 시세 조회 및 분석 서비스
+
+## 시스템 아키텍처
+
+![System Architecture](docs/architecture.png)
+
+## 기술 스택
+
+### 백엔드
+
+- Java 17
+- Spring Boot 3.2.3
+- Spring Data JPA
+- Spring Data MongoDB
+- Spring Data Redis
+- Spring Kafka
+- Spring WebSocket
+- MySQL 8.0
+- MongoDB 6.0
+- Redis 7.0
+- Apache Kafka
+
+### 프론트엔드
+
+- React
+- TypeScript
+- SockJS
+- STOMP.js
+- Chart.js
+
+### 실시간 데이터 수집
+
+- Python
+- WebSocket-client
+- Confluent-Kafka
+
+## 로컬 개발 환경 설정
+
+### 사전 요구사항
+
+- Docker Desktop
+- Java 17
+- Python 3.9+
+- Node.js 18+
+
+### 1. 백엔드 서버 및 인프라 실행
+
+```bash
+# BE 디렉토리로 이동
+cd BE
+
+# .env 파일이 있는지 확인
+ls -la .env
+
+# Docker 컨테이너 실행
+docker-compose up -d
+
+# 서비스 상태 확인
+docker-compose ps
+
+# Spring Boot 애플리케이션 실행
+./gradlew bootRun
+```
+
+### 2. 실시간 데이터 수집기 실행
+
+```bash
+cd realtime-collector
+pip install -r requirements.txt
+python main.py
+```
+
+### 3. 프론트엔드 실행
+
+```bash
+cd FE
+npm install
+npm start
+```
+
+## 서비스 접속 정보
+
+### 로컬 개발 환경
+
+- 백엔드 API: http://localhost:8080
+- 프론트엔드: http://localhost:3000
+- Kafka UI: http://localhost:8081
+
+### 모니터링
+
+- Spring Actuator: http://localhost:8080/actuator
+- MongoDB: mongodb://localhost:27017
+- Redis: localhost:6379
+- MySQL: localhost:3306
+
+## 클라우드 배포 환경 (예정)
+
+- AWS ECS (백엔드)
+- AWS MSK (Kafka)
+- AWS ElastiCache (Redis)
+- AWS DocumentDB (MongoDB)
+- AWS RDS (MySQL)
+- AWS S3 + CloudFront (프론트엔드)


### PR DESCRIPTION
# 인프라 구성 및 기본 설정 추가

## 변경사항 요약
- Docker 기반의 개발/운영 환경 구성
- 데이터베이스 및 메시징 시스템 설정
- 기본 헬스체크 API 구현
- README 문서 업데이트

## 상세 변경사항

### 인프라 구성
- MySQL: 종목 기본 정보 및 유사 종목 데이터 저장 (포트: 13306)
- MongoDB: 뉴스 및 공시 데이터 저장 (포트: 27117)
- Redis: 캐시 및 세션 데이터 저장 (포트: 16379)
- Kafka & Zookeeper: 실시간 데이터 스트리밍 (포트: 19092, 29092)
- Kafka UI: 카프카 모니터링 도구 추가 (포트: 8989)

### 설정 파일 변경
- `application.yml`: 각 데이터베이스 및 메시징 시스템 연결 설정 추가
- `build.gradle`: 의존성 업데이트 및 필요한 라이브러리 추가
- `Dockerfile`: Spring Boot 애플리케이션 컨테이너화
- `docker-compose.yml`: 전체 서비스 컨테이너 구성

### API 구현
- HealthCheckController: 각 서비스 연결 상태 모니터링 API 추가
  - MySQL 연결 상태 확인
  - MongoDB 연결 상태 확인
  - Redis 연결 상태 확인
  - Kafka 연결 상태 확인

### 문서화
- README.md 업데이트
  - 시스템 아키텍처 설명
  - 기술 스택 상세 정보
  - 로컬 개발 환경 설정 가이드
  - 서비스 접속 정보

## 테스트
- 각 서비스 컨테이너 정상 구동 확인
- 헬스체크 API 동작 확인
- 환경 변수 설정 및 보안 설정 검증

## 주의사항
- `.env` 파일이 필요하며, 민감한 정보는 환경 변수로 관리
- 각 서비스의 포트 충돌 여부 확인 필요
- Docker Desktop이 설치되어 있어야 함

## 관련 이슈
- #1 인프라 구성 및 기본 설정